### PR TITLE
Added docker-compose to make testing easier

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+---
+version: "3"
+services:
+  bun:
+    build:
+      dockerfile: Dockerfile
+      context: ./examples/bun
+    ports:
+      - 3000:3000
+    network_mode: host
+    environment:
+      - PUBLIC_KEY=${PUBLIC_KEY:-PUB_K1_5F38WK8BDCfiu3EWhb5wwrsrrat86GhVEyXp33NbDTB8DgtG4B}
+      - PORT=${PORT:-3000}
+  deno:
+    build:
+      dockerfile: Dockerfile
+      context: ./examples/deno
+    ports:
+      - 3000:3000
+    network_mode: host
+    environment:
+      - PUBLIC_KEY=${PUBLIC_KEY:-PUB_K1_5F38WK8BDCfiu3EWhb5wwrsrrat86GhVEyXp33NbDTB8DgtG4B}
+      - PORT=${PORT:-3000}
+  express:
+    build:
+      dockerfile: Dockerfile
+      context: ./examples/express
+    ports:
+      - 3000:3000
+    network_mode: host
+    environment:
+      - PUBLIC_KEY=${PUBLIC_KEY:-PUB_K1_5F38WK8BDCfiu3EWhb5wwrsrrat86GhVEyXp33NbDTB8DgtG4B}
+      - PORT=${PORT:-3000}
+  node:
+    build:
+      dockerfile: Dockerfile
+      context: ./examples/node:http
+    ports:
+      - 3000:3000
+    network_mode: host
+    environment:
+      - PUBLIC_KEY=${PUBLIC_KEY:-PUB_K1_5F38WK8BDCfiu3EWhb5wwrsrrat86GhVEyXp33NbDTB8DgtG4B}
+      - PORT=${PORT:-3000}

--- a/examples/bun/Dockerfile
+++ b/examples/bun/Dockerfile
@@ -1,0 +1,10 @@
+FROM oven/bun
+
+WORKDIR /app
+
+ENV PUBLIC_KEY $PUBLIC_KEY
+ENV PORT $PORT
+
+COPY . .
+
+CMD [ "bun", "http.ts" ]

--- a/examples/deno/Dockerfile
+++ b/examples/deno/Dockerfile
@@ -1,0 +1,10 @@
+FROM denoland/deno:alpine
+
+WORKDIR /app
+
+ENV PUBLIC_KEY $PUBLIC_KEY
+ENV PORT $PORT
+
+COPY . .
+
+CMD [ "deno", "run", "--allow-net", "--allow-read", "--allow-env", "http.ts" ]

--- a/examples/express/Dockerfile
+++ b/examples/express/Dockerfile
@@ -1,0 +1,13 @@
+FROM bitnami/express
+
+WORKDIR /app
+
+ENV PUBLIC_KEY $PUBLIC_KEY
+ENV PORT $PORT
+
+COPY . .
+
+RUN npm install --save-dev tsx
+
+CMD [ "npx", "tsx", "http.ts" ]
+

--- a/examples/node:http/Dockerfile
+++ b/examples/node:http/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20
+
+WORKDIR /app
+
+ENV PUBLIC_KEY $PUBLIC_KEY
+ENV PORT $PORT
+
+COPY . .
+
+RUN npm install --save-dev tsx
+
+CMD [ "npx", "tsx", "http.ts" ]


### PR DESCRIPTION
Created some Dockerfiles and a docker-compose to make it easier to test the config on a cluster.
It will make it easier for @coutug and others to test this application down the road.

## How to run
From the root path:
```
docker compose run <back-end>    # back-end: bun | deno | express | node
```

You can also export `PUBLIC_KEY` and `PORT` to use custom values, otherwise these defaults are going to be used:
```
PUBLIC_KEY=PUB_K1_5F38WK8BDCfiu3EWhb5wwrsrrat86GhVEyXp33NbDTB8DgtG4B
PORT=3000
```

## Back-ends running without issues
- [x] Bun
- [x] Deno
- [ ] Express (Can ping the server but the client crashes after)
- [ ] Node (Socket crashes at first but you can relaunch the server and the client will send blockchain data)

